### PR TITLE
Adding interval functionality to get_series for flexibility

### DIFF
--- a/akips/__init__.py
+++ b/akips/__init__.py
@@ -314,6 +314,7 @@ class AKIPS:
     def get_series(
         self,
         period="last1h",
+        time_interval=60,
         device="*",
         attribute="*",
         get_dict=True,
@@ -324,11 +325,13 @@ class AKIPS:
         Pull a series of counter values.
 
         AKiPS command syntax:
-            `cseries avg
-            time {time filter} type parent child attribute
+            `cseries interval avg
+            {time_interval} time {time filter} type parent child attribute
             [any|all|not group {group name} ...]`
         """
-        params = {"cmds": f"cseries avg time {period} * {device} * {attribute}"}
+        params = {
+            "cmds": f"cseries interval avg {time_interval} time {period} * {device} * {attribute}"
+        }
         if groups:
             group_list = " ".join(groups)
             params["cmds"] += f" {group_filter} group {group_list}"


### PR DESCRIPTION
During my business case with AKiPS I found myself wanting to get the series information for longer timespans such as last 30/60/90 days. With the current implementation we are limited to the minimum 60seconds. 
Changing this to interval we allow the customization of the interval being retrieved while still maintaining the original 60 seconds, last1h like before.