### PR TITLE
typo in mget command for get_attributes

### DIFF
--- a/akips/__init__.py
+++ b/akips/__init__.py
@@ -3,13 +3,14 @@ the AKiPS Network Monitoring Software Web API interface."""
 
 __version__ = "0.4.2"
 
-import io
-import re
-import logging
-from datetime import datetime
-import requests
-import pytz
 import csv
+import io
+import logging
+import re
+from datetime import datetime
+
+import pytz
+import requests
 
 from akips.exceptions import AkipsError
 
@@ -282,7 +283,7 @@ class AKIPS:
                 [any|all|not group {group name} ...]`
         """
         params = {
-            "cmds": f"mget * {device} {child} {attribute}/",
+            "cmds": f"mget * {device} {child} {attribute}",
         }
         if value:
             # [value {text|/regex/|integer|ipaddr}]


### PR DESCRIPTION
Noticed a typo in the function get_attributes that causes that to not output anything due to being invalid.